### PR TITLE
Convert Expr abstract class to interface

### DIFF
--- a/wagago/AstPrinter.cs
+++ b/wagago/AstPrinter.cs
@@ -3,75 +3,75 @@
     /// <summary>
     ///     A kind of visitor for Wagago that prints the AST to the console
     /// </summary>
-    public class AstPrinter : Expr.IVisitor<string>
+    public class AstPrinter : IExpr.IVisitor<string>
     {
-        string Expr.IVisitor<string>.VisitBinaryExpr(Binary expr)
+        string IExpr.IVisitor<string>.VisitBinaryExpr(Binary expr)
         {
             return Parenthesize(expr.Operatr.lexeme, expr.Left, expr.Right);
         }
 
-        string Expr.IVisitor<string>.VisitInvocationExpr(Invocation expr)
+        string IExpr.IVisitor<string>.VisitInvocationExpr(Invocation expr)
         {
             throw new NotImplementedException();
         }
 
-        string Expr.IVisitor<string>.VisitPropGetExpr(PropGet expr)
+        string IExpr.IVisitor<string>.VisitPropGetExpr(PropGet expr)
         {
             throw new NotImplementedException();
         }
 
-        string Expr.IVisitor<string>.VisitPropSetExpr(PropSet expr)
+        string IExpr.IVisitor<string>.VisitPropSetExpr(PropSet expr)
         {
             throw new NotImplementedException();
         }
 
-        string Expr.IVisitor<string>.VisitSuperExpr(Super expr)
+        string IExpr.IVisitor<string>.VisitSuperExpr(Super expr)
         {
             throw new NotImplementedException();
         }
 
-        string Expr.IVisitor<string>.VisitGroupingExpr(Grouping expr)
+        string IExpr.IVisitor<string>.VisitGroupingExpr(Grouping expr)
         {
             return Parenthesize("group", expr.Expression);
         }
 
-        string Expr.IVisitor<string>.VisitLiteralExpr(Literal expr)
+        string IExpr.IVisitor<string>.VisitLiteralExpr(Literal expr)
         {
             return expr.Value.Equals(null) ? "nil" : expr.Value.ToString() ?? "nil";
         }
 
-        string Expr.IVisitor<string>.VisitLogicalExpr(Logical expr)
+        string IExpr.IVisitor<string>.VisitLogicalExpr(Logical expr)
         {
             throw new NotImplementedException();
         }
 
-        string Expr.IVisitor<string>.VisitThisExpr(This expr)
+        string IExpr.IVisitor<string>.VisitThisExpr(This expr)
         {
             throw new NotImplementedException();
         }
 
-        string Expr.IVisitor<string>.VisitUnaryExpr(Unary expr)
+        string IExpr.IVisitor<string>.VisitUnaryExpr(Unary expr)
         {
             return Parenthesize(expr.Operatr.lexeme, expr.Right);
         }
 
-        string Expr.IVisitor<string>.VisitVariableExpr(Variable expr)
+        string IExpr.IVisitor<string>.VisitVariableExpr(Variable expr)
         {
             
             throw new NotImplementedException();
         }
         
-        string Expr.IVisitor<string>.VisitAssignExpr(Assign expr)
+        string IExpr.IVisitor<string>.VisitAssignExpr(Assign expr)
         {
             throw new NotImplementedException();
         }
 
-        internal string Print(Expr expr)
+        internal string Print(IExpr expr)
         {
             return expr.Accept(this);
         }
 
-        private string Parenthesize(string name, params Expr[] exprs)
+        private string Parenthesize(string name, params IExpr[] exprs)
         {
             var output = new List<string>
             {

--- a/wagago/Expr.cs
+++ b/wagago/Expr.cs
@@ -1,8 +1,8 @@
 namespace Wagago
 {
-  internal abstract class Expr
+  internal interface IExpr
   {
-    public abstract TR Accept<TR>(IVisitor<TR> visitor);
+    public TR Accept<TR>(IVisitor<TR> visitor);
 
    internal interface IVisitor<out TR> {
       TR VisitAssignExpr(Assign expr);
@@ -19,93 +19,93 @@ namespace Wagago
       TR VisitVariableExpr(Variable expr);
     }
   }
- internal class Assign: Expr
+ internal class Assign: IExpr
   {
-    internal Assign(Token identifier, Expr value)
+    internal Assign(Token identifier, IExpr value)
     {
       Identifier = identifier;
       Value = value;
     }
 
-    public override TR Accept<TR>(IVisitor<TR> visitor)
+    public TR Accept<TR>(IExpr.IVisitor<TR> visitor)
     {
       return visitor.VisitAssignExpr(this);
     }
 
     public readonly Token Identifier;
-    public readonly Expr Value;
+    public readonly IExpr Value;
   }
- internal class Binary: Expr
+ internal class Binary: IExpr
   {
-    internal Binary(Expr left, Token operatr, Expr right)
+    internal Binary(IExpr left, Token operatr, IExpr right)
     {
       Left = left;
       Operatr = operatr;
       Right = right;
     }
 
-    public override TR Accept<TR>(IVisitor<TR> visitor)
+    public TR Accept<TR>(IExpr.IVisitor<TR> visitor)
     {
       return visitor.VisitBinaryExpr(this);
     }
 
-    public readonly Expr Left;
+    public readonly IExpr Left;
     public readonly Token Operatr;
-    public readonly Expr Right;
+    public readonly IExpr Right;
   }
- internal class Invocation: Expr
+ internal class Invocation: IExpr
   {
-    internal Invocation(Expr callee, Token paren, List<Expr> arguments)
+    internal Invocation(IExpr callee, Token paren, List<IExpr> arguments)
     {
       Callee = callee;
       Paren = paren;
       Arguments = arguments;
     }
 
-    public override TR Accept<TR>(IVisitor<TR> visitor)
+    public TR Accept<TR>(IExpr.IVisitor<TR> visitor)
     {
       return visitor.VisitInvocationExpr(this);
     }
 
-    public readonly Expr Callee;
+    public readonly IExpr Callee;
     public readonly Token Paren;
-    public readonly List<Expr> Arguments;
+    public readonly List<IExpr> Arguments;
   }
- internal class PropGet: Expr
+ internal class PropGet: IExpr
   {
-    internal PropGet(Expr owner, Token name)
+    internal PropGet(IExpr owner, Token name)
     {
       Owner = owner;
       Name = name;
     }
 
-    public override TR Accept<TR>(IVisitor<TR> visitor)
+    public TR Accept<TR>(IExpr.IVisitor<TR> visitor)
     {
       return visitor.VisitPropGetExpr(this);
     }
 
-    public readonly Expr Owner;
+    public readonly IExpr Owner;
     public readonly Token Name;
   }
- internal class PropSet: Expr
+ internal class PropSet: IExpr
   {
-    internal PropSet(Expr owner, Token name, Expr value)
+    internal PropSet(IExpr owner, Token name, IExpr value)
     {
       Owner = owner;
       Name = name;
       Value = value;
     }
 
-    public override TR Accept<TR>(IVisitor<TR> visitor)
+    public TR Accept<TR>(IExpr.IVisitor<TR> visitor)
     {
       return visitor.VisitPropSetExpr(this);
     }
 
-    public readonly Expr Owner;
+    public readonly IExpr Owner;
     public readonly Token Name;
-    public readonly Expr Value;
+    public readonly IExpr Value;
   }
- internal class Super: Expr
+ internal class Super: IExpr
   {
     internal Super(Token keyword, Token method)
     {
@@ -113,7 +113,7 @@ namespace Wagago
       Method = method;
     }
 
-    public override TR Accept<TR>(IVisitor<TR> visitor)
+    public TR Accept<TR>(IExpr.IVisitor<TR> visitor)
     {
       return visitor.VisitSuperExpr(this);
     }
@@ -121,90 +121,90 @@ namespace Wagago
     public readonly Token Keyword;
     public readonly Token Method;
   }
- internal class Grouping: Expr
+ internal class Grouping: IExpr
   {
-    internal Grouping(Expr expression)
+    internal Grouping(IExpr expression)
     {
       Expression = expression;
     }
 
-    public override TR Accept<TR>(IVisitor<TR> visitor)
+    public TR Accept<TR>(IExpr.IVisitor<TR> visitor)
     {
       return visitor.VisitGroupingExpr(this);
     }
 
-    public readonly Expr Expression;
+    public readonly IExpr Expression;
   }
- internal class Literal: Expr
+ internal class Literal: IExpr
   {
     internal Literal(object value)
     {
       Value = value;
     }
 
-    public override TR Accept<TR>(IVisitor<TR> visitor)
+    public TR Accept<TR>(IExpr.IVisitor<TR> visitor)
     {
       return visitor.VisitLiteralExpr(this);
     }
 
     public readonly object Value;
   }
- internal class Logical: Expr
+ internal class Logical: IExpr
   {
-    internal Logical(Expr left, Token operatr, Expr right)
+    internal Logical(IExpr left, Token operatr, IExpr right)
     {
       Left = left;
       Operatr = operatr;
       Right = right;
     }
 
-    public override TR Accept<TR>(IVisitor<TR> visitor)
+    public TR Accept<TR>(IExpr.IVisitor<TR> visitor)
     {
       return visitor.VisitLogicalExpr(this);
     }
 
-    public readonly Expr Left;
+    public readonly IExpr Left;
     public readonly Token Operatr;
-    public readonly Expr Right;
+    public readonly IExpr Right;
   }
- internal class This: Expr
+ internal class This: IExpr
   {
     internal This(Token keyword)
     {
       Keyword = keyword;
     }
 
-    public override TR Accept<TR>(IVisitor<TR> visitor)
+    public TR Accept<TR>(IExpr.IVisitor<TR> visitor)
     {
       return visitor.VisitThisExpr(this);
     }
 
     public readonly Token Keyword;
   }
- internal class Unary: Expr
+ internal class Unary: IExpr
   {
-    internal Unary(Token operatr, Expr right)
+    internal Unary(Token operatr, IExpr right)
     {
       Operatr = operatr;
       Right = right;
     }
 
-    public override TR Accept<TR>(IVisitor<TR> visitor)
+    public TR Accept<TR>(IExpr.IVisitor<TR> visitor)
     {
       return visitor.VisitUnaryExpr(this);
     }
 
     public readonly Token Operatr;
-    public readonly Expr Right;
+    public readonly IExpr Right;
   }
- internal class Variable: Expr
+ internal class Variable: IExpr
   {
     internal Variable(Token name)
     {
       Name = name;
     }
 
-    public override TR Accept<TR>(IVisitor<TR> visitor)
+    public TR Accept<TR>(IExpr.IVisitor<TR> visitor)
     {
       return visitor.VisitVariableExpr(this);
     }

--- a/wagago/Parser.cs
+++ b/wagago/Parser.cs
@@ -77,13 +77,13 @@
             _tokens = tokens;
         }
 
-        private Expr ParseExpression()
+        private IExpr ParseExpression()
         {
             // descend into the equality rule
             return Assignment();
         }
 
-        private Expr Assignment()
+        private IExpr Assignment()
         {
             // 1. keep evaluating until you reach `primary` which would return an IDENTIFIER
             // cursor moves forward
@@ -111,7 +111,7 @@
             }
         }
 
-        private Expr Or()
+        private IExpr Or()
         {
             var expr = And();
 
@@ -125,7 +125,7 @@
             return expr;
         }
 
-        private Expr And()
+        private IExpr And()
         {
             var expr = Equality();
             
@@ -146,7 +146,7 @@
         ///     </code>
         /// </summary>
         /// <returns></returns>
-        private Expr Equality()
+        private IExpr Equality()
         {
             // the first non-terminal comparison
             // descend into the comparison rule
@@ -175,7 +175,7 @@
         ///     </code>
         /// </summary>
         /// <returns></returns>
-        private Expr TokenComparison()
+        private IExpr TokenComparison()
         {
             var expr = Term();
 
@@ -197,7 +197,7 @@
         ///     </code>
         /// </summary>
         /// <returns></returns>
-        private Expr Term()
+        private IExpr Term()
         {
             var expr = Factor();
 
@@ -218,7 +218,7 @@
         ///     </code>
         /// </summary>
         /// <returns></returns>
-        private Expr Factor()
+        private IExpr Factor()
         {
             var expr = TokenUnary();
 
@@ -239,7 +239,7 @@
         ///     </code>
         /// </summary>
         /// <returns></returns>
-        private Expr TokenUnary()
+        private IExpr TokenUnary()
         {
             if (!Match(TokenType.BANG, TokenType.MINUS)) return Invocation();
             var optr = Previous();
@@ -247,7 +247,7 @@
             return new Unary(optr, right);
         }
 
-        private Expr Invocation()
+        private IExpr Invocation()
         {
             var expr = Primary();
 
@@ -271,9 +271,9 @@
             return expr;
         }
 
-        private Expr FinishInvocation(Expr callee)
+        private IExpr FinishInvocation(IExpr callee)
         {
-            var args = new List<Expr>();
+            var args = new List<IExpr>();
             if (!Check(TokenType.RIGHT_PAREN))
             {
                 // while there's a comma, collate arguments
@@ -300,7 +300,7 @@
         ///     </code>
         /// </summary>
         /// <returns></returns>
-        private Expr Primary()
+        private IExpr Primary()
         {
             if (Match(TokenType.FALSE)) return new Literal(false);
             if (Match(TokenType.TRUE)) return new Literal(true);
@@ -533,7 +533,7 @@
             // 1. get the identifier
             var name = Consume(TokenType.IDENTIFIER, "Expect variable name");
 
-            Expr initializer = null;
+            IExpr initializer = null;
             
             // 2. if the next token is "=", we handle the variable definition
             // and parse the expression that follows
@@ -640,14 +640,14 @@
                 initializer = ExpressionStatement();
             }
 
-            Expr condition = null;
+            IExpr condition = null;
             if (!Check(TokenType.SEMICOLON))
             {
                 condition = ParseExpression();
             }
             Consume(TokenType.SEMICOLON, "Expect ';' after loop condition.");
 
-            Expr increment = null;
+            IExpr increment = null;
             if (!Check(TokenType.RIGHT_PAREN))
             {
                 increment = ParseExpression();
@@ -676,7 +676,7 @@
         {
             // keep the 'return' keyword so the location can be used for error reporting
             var keyword = Previous();
-            Expr value = null;
+            IExpr value = null;
             if (!Check(TokenType.SEMICOLON))
             {
                 value = ParseExpression();

--- a/wagago/Resolver.cs
+++ b/wagago/Resolver.cs
@@ -6,7 +6,7 @@
     ///     - define scopes for blocks and functions
     /// </para>
     /// </summary>
-    public class Resolver: Expr.IVisitor<object>, Stmt.IVisitor<object>
+    public class Resolver: IExpr.IVisitor<object>, Stmt.IVisitor<object>
     {
         private readonly Interpreter _interpreter;
         private readonly Stack<Dictionary<string, bool>> _scopes = new ();
@@ -33,21 +33,21 @@
             _interpreter = interpreter;
         }
 
-        object Expr.IVisitor<object>.VisitAssignExpr(Assign expr)
+        object IExpr.IVisitor<object>.VisitAssignExpr(Assign expr)
         {
             Resolve(expr.Value);
             ResolveLocal(expr, expr.Identifier);
             return null;
         }
 
-        object Expr.IVisitor<object>.VisitBinaryExpr(Binary expr)
+        object IExpr.IVisitor<object>.VisitBinaryExpr(Binary expr)
         {
             Resolve(expr.Left);
             Resolve(expr.Right);
             return null;
         }
 
-        object Expr.IVisitor<object>.VisitInvocationExpr(Invocation expr)
+        object IExpr.IVisitor<object>.VisitInvocationExpr(Invocation expr)
         {
             Resolve(expr.Callee);
             foreach (var arg in expr.Arguments)
@@ -58,20 +58,20 @@
             return null;
         }
 
-        object Expr.IVisitor<object>.VisitPropGetExpr(PropGet expr)
+        object IExpr.IVisitor<object>.VisitPropGetExpr(PropGet expr)
         {
             Resolve(expr.Owner);
             return null;
         }
 
-        object Expr.IVisitor<object>.VisitPropSetExpr(PropSet expr)
+        object IExpr.IVisitor<object>.VisitPropSetExpr(PropSet expr)
         {
             Resolve(expr.Value);
             Resolve(expr.Owner);
             return null;
         }
 
-        object Expr.IVisitor<object>.VisitSuperExpr(Super expr)
+        object IExpr.IVisitor<object>.VisitSuperExpr(Super expr)
         {
             if (_currentClass == ClassType.NONE)
             {
@@ -85,25 +85,25 @@
             return null;
         }
 
-        object Expr.IVisitor<object>.VisitGroupingExpr(Grouping expr)
+        object IExpr.IVisitor<object>.VisitGroupingExpr(Grouping expr)
         {
             Resolve(expr.Expression);
             return null;
         }
 
-        object Expr.IVisitor<object>.VisitLiteralExpr(Literal expr)
+        object IExpr.IVisitor<object>.VisitLiteralExpr(Literal expr)
         {
             return null;
         }
 
-        object Expr.IVisitor<object>.VisitLogicalExpr(Logical expr)
+        object IExpr.IVisitor<object>.VisitLogicalExpr(Logical expr)
         {
             Resolve(expr.Left);
             Resolve(expr.Right);
             return null;
         }
 
-        object Expr.IVisitor<object>.VisitThisExpr(This expr)
+        object IExpr.IVisitor<object>.VisitThisExpr(This expr)
         {
             if (_currentClass == ClassType.NONE)
             {
@@ -114,13 +114,13 @@
             return null;
         }
 
-        object Expr.IVisitor<object>.VisitUnaryExpr(Unary expr)
+        object IExpr.IVisitor<object>.VisitUnaryExpr(Unary expr)
         {
             Resolve(expr.Right);
             return null;
         }
 
-        object Expr.IVisitor<object>.VisitVariableExpr(Variable expr)
+        object IExpr.IVisitor<object>.VisitVariableExpr(Variable expr)
         {
 
             if (_scopes.Count > 0)
@@ -292,7 +292,7 @@
             stmt.Accept(this);
         }
 
-        private void Resolve(Expr expr)
+        private void Resolve(IExpr expr)
         {
             expr.Accept(this);
         }
@@ -353,7 +353,7 @@
         /// </summary>
         /// <param name="expr"></param>
         /// <param name="exprName"></param>
-        private void ResolveLocal(Expr expr, Token exprName)
+        private void ResolveLocal(IExpr expr, Token exprName)
         {
             var scopesArray = _scopes.ToArray();
             for (var i = _scopes.Count - 1; i >= 0; i--)

--- a/wagago/Stmt.cs
+++ b/wagago/Stmt.cs
@@ -50,7 +50,7 @@ namespace Wagago
   }
  internal class Expression: Stmt
   {
-    internal Expression(Expr expressn)
+    internal Expression(IExpr expressn)
     {
       Expressn = expressn;
     }
@@ -60,11 +60,11 @@ namespace Wagago
       return visitor.VisitExpressionStmt(this);
     }
 
-    public readonly Expr Expressn;
+    public readonly IExpr Expressn;
   }
  internal class Print: Stmt
   {
-    internal Print(Expr expression)
+    internal Print(IExpr expression)
     {
       Expression = expression;
     }
@@ -74,11 +74,11 @@ namespace Wagago
       return visitor.VisitPrintStmt(this);
     }
 
-    public readonly Expr Expression;
+    public readonly IExpr Expression;
   }
  internal class If: Stmt
   {
-    internal If(Expr condition, Stmt thenBranch, Stmt elseBranch)
+    internal If(IExpr condition, Stmt thenBranch, Stmt elseBranch)
     {
       Condition = condition;
       ThenBranch = thenBranch;
@@ -90,13 +90,13 @@ namespace Wagago
       return visitor.VisitIfStmt(this);
     }
 
-    public readonly Expr Condition;
+    public readonly IExpr Condition;
     public readonly Stmt ThenBranch;
     public readonly Stmt ElseBranch;
   }
  internal class While: Stmt
   {
-    internal While(Expr condition, Stmt body)
+    internal While(IExpr condition, Stmt body)
     {
       Condition = condition;
       Body = body;
@@ -107,12 +107,12 @@ namespace Wagago
       return visitor.VisitWhileStmt(this);
     }
 
-    public readonly Expr Condition;
+    public readonly IExpr Condition;
     public readonly Stmt Body;
   }
  internal class Var: Stmt
   {
-    internal Var(Token identifier, Expr initializer)
+    internal Var(Token identifier, IExpr initializer)
     {
       Identifier = identifier;
       Initializer = initializer;
@@ -124,11 +124,11 @@ namespace Wagago
     }
 
     public readonly Token Identifier;
-    public readonly Expr Initializer;
+    public readonly IExpr Initializer;
   }
  internal class Return: Stmt
   {
-    internal Return(Token keyword, Expr value)
+    internal Return(Token keyword, IExpr value)
     {
       Keyword = keyword;
       Value = value;
@@ -140,7 +140,7 @@ namespace Wagago
     }
 
     public readonly Token Keyword;
-    public readonly Expr Value;
+    public readonly IExpr Value;
   }
  internal class Func: Stmt
   {


### PR DESCRIPTION
### Motivation
The purpose of an [abstract class](https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/abstract-and-sealed-classes-and-class-members) is to provide some overridable behaviors while also defining methods that are required to be implemented by sub-classes.

A class that contains only abstract methods, often called pure abstract class, is effectively an interface, but with the disadvantage of not being able to be implemented by multiple classes.

Using interfaces over pure abstract classes presents multiple advantages:

[Multiple Inheritance](https://en.wikipedia.org/wiki/Multiple_inheritance): Unlike classes, an interface doesn’t count towards the single inheritance limit in C#. This means a class can implement multiple interfaces, which can be useful when you need to define behavior that can be shared across multiple classes.
[Loose Coupling](https://en.wikipedia.org/wiki/Loose_coupling#In_programming): Interfaces provide a way to achieve loose coupling between classes. This is because an interface only specifies what methods a class must have, but not how they are implemented. This makes it easier to swap out implementations without changing the code that uses them.
[Polymorphism](https://en.wikipedia.org/wiki/Polymorphism_(computer_science)): Interfaces allow you to use polymorphism, which means you can use an interface type to refer to any object that implements that interface. This can be useful when you want to write code that can work with any class that implements a certain interface, without knowing what the actual class is.
[Design by contract](https://en.wikipedia.org/wiki/Design_by_contract): Interfaces provide a clear contract of what a class should do, without specifying how it should do it. This makes it easier to understand the intended behavior of a class, and to ensure that different implementations of an interface are consistent with each other.